### PR TITLE
Update demo to clone specific collection version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 CONTAINER ?= avdteam/base:3.6
+VSCODE_CONTAINER ?= avdteam/vscode:latest
+VSCODE_PORT ?= 8080
 HOME_DIR = $(shell pwd)
+AVD_COLLECTION_VERSION ?= v1.1.2
+CVP_COLLECTION_VERSION ?= v2.1.1
 
 help: ## Display help message
 	@grep -E '^[0-9a-zA-Z_-]+\.*[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -34,9 +38,9 @@ configlet-upload: ## Upload configlets available in configlets/ to CVP.
 
 .PHONY: install
 install: ## Install Ansible collections
-	git clone https://github.com/aristanetworks/ansible-avd.git
-	git clone https://github.com/aristanetworks/ansible-cvp.git
-	pip3 install -r requirements.txt
+	git clone --depth 1 --branch $(AVD_COLLECTION_VERSION) https://github.com/aristanetworks/ansible-avd.git
+	git clone --depth 1 --branch $(CVP_COLLECTION_VERSION) https://github.com/aristanetworks/ansible-cvp.git
+	pip3 install -r ansible-avd/development/requirements.txt
 
 .PHONY: uninstall
 uninstall: ## Remove collection from ansible
@@ -53,3 +57,13 @@ shell: ## Start docker to get a preconfigured shell
 	docker run --rm -it \
 		-v $(HOME_DIR)/:/projects \
 		-v /etc/hosts:/etc/hosts $(CONTAINER)
+
+.PHONY: vscode
+vscode: ## Run a vscode server on port 8080
+	docker run --rm -it -d \
+		-e AVD_GIT_USER="$(git config --get user.name)" \
+		-e AVD_GIT_EMAIL="$(git config --get user.email)" \
+		-v $(HOME_DIR):/home/avd/ansible-avd-cloudvision-demo \
+		-p $(VSCODE_PORT):8080 $(VSCODE_CONTAINER)
+	@echo "---------------"
+	@echo "VScode for AVD: http://127.0.0.1:$(VSCODE_PORT)/?folder=/home/avd/ansible-avd-cloudvision-demo"


### PR DESCRIPTION
Now clone process target a specific version of both AVD and CVP collection.

To override this use the following option with makefile:

```
make install AVD_COLLECTION_VERSION=devel CVP_COLLECTION_VERSION=devel
```

Another make command has been added to support vscode in browser to run
demo:

```
make vscode
```