### PR TITLE
Fix: Update Installation guides to install community.general collection

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -79,6 +79,7 @@ $ make install
 #  Manual installation
 $ ansible-galaxy collection install arista.avd:==2.0.0
 $ ansible-galaxy collection install arista.cvp:==2.1.2
+$ ansible-galaxy collection install community.general
 ```
 
 ## Configure DHCP server on CloudVision

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ install-git: ## Install Ansible collections from git
 install: ## Install Ansible collections
 	ansible-galaxy collection install arista.avd:==${AVD_COLLECTION_VERSION}
 	ansible-galaxy collection install arista.cvp:==${CVP_COLLECTION_VERSION}
+	ansible-galaxy collection install community.general
 
 .PHONY: uninstall
 uninstall: ## Remove collection from ansible

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ $ make shell
 # Install required ansible collections
 $ ansible-galaxy collection install arista.avd:==2.0.0
 $ ansible-galaxy collection install arista.cvp:==2.1.2
+$ ansible-galaxy collection install community.general
 
 # Edit Inventory information & Authentication information
 $ vim inventory/inventory.yml


### PR DESCRIPTION
`arista.avd` is no longer requiring this collection, so it will not be installed automatically.
Since this demo use callbacks contained in the `community.general` collection, it should be installed.