### PR TITLE
Bump: Update markupsafe and cvprac

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,10 @@ ansible==4.2.0
 netaddr==0.7.19
 Jinja2==2.11.3
 treelib==1.5.5
-cvprac==1.0.5
+cvprac==1.0.7
 paramiko==2.7.1
 jsonschema==3.2.0
 requests==2.25.1
 PyYAML==5.4.1
 md-toc==7.1.0
+markupsafe==2.0.1


### PR DESCRIPTION
Avoid breaking change in markupsafe 2.1
Update cvprac requirements